### PR TITLE
Atualizar rodapé para exibir o ano atual dinamicamente

### DIFF
--- a/index.html
+++ b/index.html
@@ -2188,7 +2188,11 @@
     <footer class="rodape">
       <div>
           <a href="https://github.com/robertdouglasaimon" target="_blank">
-            <p>Robert Douglas ©  2024</p>
+              <p>Robert Douglas ©  
+                <script> /* JavaScript para exibir o ano atual no rodapé */
+                  document.write(new Date().getFullYear());
+                </script>
+              </p>
           </a>
       </div>
     </footer>


### PR DESCRIPTION
Substituí o ano estático no rodapé por JavaScript para exibir automaticamente o ano atual. Isso garante que o ano do copyright permaneça atualizado.